### PR TITLE
fixed reagent version number to current

### DIFF
--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -75,7 +75,7 @@
 (defn dependencies [opts]
   (cond-> []
           (om?      opts) (conj "org.omcljs/om \"0.8.6\"")
-          (reagent? opts) (conj "reagent \"0.5.0-SNAPSHOT\"")
+          (reagent? opts) (conj "reagent \"0.5.0-alpha3\"")
           (garden?  opts) (conj "boot-garden \"1.2.5-1\"")
           (sass?    opts) (conj "boot-sassc  \"0.1.0\"")))
 


### PR DESCRIPTION
When I tried tenzing with the +reagent flag, boot threw an error about not finding the reagent dependency. Changing the version number to the most up to date solved the issue.