### PR TITLE
Update reagent dependency and scope garden to test

### DIFF
--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -76,7 +76,7 @@
   (cond-> []
           (om?      opts) (conj "org.omcljs/om \"0.8.6\"")
           (reagent? opts) (conj "reagent \"0.5.0-alpha3\"")
-          (garden?  opts) (conj "boot-garden \"1.2.5-1\"")
+          (garden?  opts) (conj "boot-garden \"1.2.5-1\" :scope \"test\"")
           (sass?    opts) (conj "boot-sassc  \"0.1.0\"")))
 
 (defn build-requires [opts]


### PR DESCRIPTION
Hi Martin,

Trying to generate a new project with +reagent failed because it couldn't find reagent 0.5.0-SNAPSHOT in Clojars. I updated to 0.5.0-alpha3. Also, garden is really only needed during dev/test for generation so I scoped it accordingly. So, just some really small changes, but good ones I think. :) Thanks for your work on this lein template. 

—Cheers