### PR TITLE
Add basic .gitignore to the created application

### DIFF
--- a/resources/leiningen/new/tenzing/gitignore
+++ b/resources/leiningen/new/tenzing/gitignore
@@ -1,0 +1,2 @@
+/target
+/.nrepl-port

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -167,4 +167,5 @@
 
                            ["resources/js/app.cljs.edn" (render "app.cljs.edn" data)]
                            ["resources/index.html" (render "index.html" data)]
-                           ["build.boot" (render "build.boot" data)])))))
+                           ["build.boot" (render "build.boot" data)]
+                           [".gitignore" (render "gitignore" data)])))))


### PR DESCRIPTION
So far just ignoring the /target dir and the nrepl port file.