### PR TITLE
Add +test option

### DIFF
--- a/README.org
+++ b/README.org
@@ -87,6 +87,7 @@ project will contain:
 - =+garden= sets up [[https://github.com/noprompt/garden][Garden]] and integrates into the build process
 - =+sass= sets up [[http://sass-lang.com][Sass]] and integrates into the build process (requires [[http://libsass.org][libsass]])
 - =+less= sets up [[http://lesscss.org/][Less]] and integrates into the build process.
+- =+test= adds a [[https://github.com/crisptrutski/boot-cljs-test][cljs test-runner]] and adds a =test= task.
 
 If you want to add an option, [[https://github.com/martinklepsch/tenzing][pull-requests]] are welcome.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tenzing/lein-template "0.3.1"
+(defproject tenzing/lein-template "0.3.2-SNAPSHOT"
   :description "Clojurescript application template built on Boot"
   :url "http://github.com/martinklepsch/tenzing"
   :license {:name "Eclipse Public License"

--- a/resources/leiningen/new/tenzing/app_test.cljs
+++ b/resources/leiningen/new/tenzing/app_test.cljs
@@ -1,0 +1,7 @@
+(ns {{name}}.app-test
+  (:require-macros [cljs.test :refer [deftest testing is]])
+  (:require [cljs.test :as t]
+            [{{name}}.app :as app]))
+
+(deftest test-arithmetic []
+  (is (= (+ 0.1 0.2) 0.3) "Something foul is a float."))

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -3,8 +3,8 @@
  :resource-paths  #{"resources"}
  :dependencies '[[adzerk/boot-cljs      "0.0-2814-4" :scope "test"]
                  [adzerk/boot-cljs-repl "0.1.9"      :scope "test"]
-                 [adzerk/boot-reload    "0.2.4"      :scope "test"]
-                 [pandeiro/boot-http    "0.6.1"      :scope "test"]{{{deps}}}])
+                 [adzerk/boot-reload    "0.3.1"      :scope "test"]
+                 [pandeiro/boot-http    "0.6.2"      :scope "test"]{{{deps}}}])
 
 (require
  '[adzerk.boot-cljs      :refer [cljs]]

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -41,3 +41,5 @@
   []
   (comp (development)
         (run)))
+
+{{{tasks}}}


### PR DESCRIPTION
Refs #27 

Some obvious areas for improvement:

1. Having issues with some environments, eg. slimerjs is not showing output, and node chokes on absolute file paths. Will submit patches upstream.
2. `clojure.core/test` is clobbered. Is there a `(:refer-clojure :exclusions [...])` mechanism for `build.boot` files?
3. Test runner is very aggressive about what namespaces are tested - testing regular project namespaces, and even some namespaces outside the project. Could perhaps limit itself to specific source-paths, and perhaps even use a filename regex (so `/tests/fixtures.cljs` would not be run for example).
4. The mechanism for "invading" the build (stripping all .cljs.edn, and getting a new one generated) is too drastic, and also gives no control over what code is required (so everything is required). Generating a bespoke .cljs.edn, and (if boot-cljs gets this feature) targeting it directly, would prov. 
5. Along the lines of (3), it should be possible to use an existing .cljs.edn file, and just add the :require on the suite.

Moving back a step - starter test suites specifically for Reagent and Om would be nice.

On a code note - adding extra tasks is quite messing without #2 