### PR TITLE
Produce boot.properties file

### DIFF
--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -148,7 +148,7 @@
     (main/exit)))
 
 (defn render-boot-properties []
-  (let [{:keys [exit out err]} (sh/sh "boot" "-V")]
+  (let [{:keys [exit out err]} (sh/sh "boot" "-V" :env {:BOOT_CLOJURE_VERSION "1.7.0"})]
     (if (pos? exit)
       (println "WARNING: unable to produce boot.properties file.")
       out)))

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -2,7 +2,8 @@
   (:require [leiningen.new.templates :as t :refer [name-to-path ->files sanitize slurp-resource]]
             [leiningen.core.main :as main]
             [clojure.string :as string]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.java.shell :as sh]))
 
 
 ;; potentially write a function here that can be called like (prettify
@@ -146,6 +147,12 @@
     (main/warn "Please specify only +om or +reagent, not both.")
     (main/exit)))
 
+(defn render-boot-properties []
+  (let [{:keys [exit out err]} (sh/sh "boot" "-V")]
+    (if (pos? exit)
+      (println "WARNING: unable to produce boot.properties file.")
+      out)))
+
 (defn tenzing
   "Main function to generate new tenzing project."
   [name & opts]
@@ -167,5 +174,9 @@
 
                            ["resources/js/app.cljs.edn" (render "app.cljs.edn" data)]
                            ["resources/index.html" (render "index.html" data)]
+
+                           (when-let [boot-props (render-boot-properties)]
+                             ["boot.properties" boot-props])
+
                            ["build.boot" (render "build.boot" data)]
                            [".gitignore" (render "gitignore" data)])))))


### PR DESCRIPTION
Seems to me that adding a `boot.properties` file is "best practice" in any case, but this also helps support #29

Not sure if this is the best way to go about it, perhaps a regular template is better (depends on whether you want to fin the boot version, and whether users already have boot installed)