### PR TITLE
Improve cljs-test defaults

### DIFF
--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -107,13 +107,13 @@
 
 (deftask test []
   (comp (testing)
-        (test-cljs :js-env :rhino
+        (test-cljs :js-env :phantomjs
                    :exit?  true)))
 
 (deftask auto-test []
   (comp (testing)
         (watch)
-        (test-cljs :js-env :rhino)))")
+        (test-cljs :js-env :phantomjs)))")
 
 (defn build-tasks [opts]
   (cond-> []

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -107,7 +107,8 @@
 
 (deftask test []
   (comp (testing)
-        (test-cljs :js-env :rhino)))
+        (test-cljs :js-env :rhino
+                   :exit?  true)))
 
 (deftask auto-test []
   (comp (testing)


### PR DESCRIPTION
* Exit with return code in default test task (ie. CI friendly)
* Make phantomjs the default (because https://github.com/bensu/doo/issues/20)