### PR TITLE
Update versions

### DIFF
--- a/resources/leiningen/new/tenzing/app.cljs.edn
+++ b/resources/leiningen/new/tenzing/app.cljs.edn
@@ -1,2 +1,3 @@
 {:require  [{{name}}.app]
- :init-fns [{{name}}.app/init]}
+ :init-fns [{{name}}.app/init]
+ :compiler-options {:asset-path "js/app.out"}}

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -1,11 +1,11 @@
 (set-env!
  :source-paths    {{{source-paths}}}
  :resource-paths  #{"resources"}
- :dependencies '[[adzerk/boot-cljs          "0.0-3308-0" :scope "test"]
                  [adzerk/boot-cljs-repl     "0.1.9"      :scope "test"]
                  [adzerk/boot-reload        "0.3.1"      :scope "test"]
+ :dependencies '[[adzerk/boot-cljs          "1.7.48-6"   :scope "test"]
                  [pandeiro/boot-http        "0.6.3"      :scope "test"]
-                 [org.clojure/clojurescript "1.7.58"]{{{deps}}}])
+                 [org.clojure/clojurescript "1.7.122"]{{{deps}}}])
 
 (require
  '[adzerk.boot-cljs      :refer [cljs]]

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -31,9 +31,7 @@
   identity)
 
 (deftask development []
-  (task-options! cljs {:optimizations :none
-                       :compiler-options {:asset-path "js/app.out"}
-                       :source-map true}
+  (task-options! cljs {:optimizations :none :source-map true}
                  reload {:on-jsload '{{name}}.app/init}{{{development-task-opts}}})
   identity)
 

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -33,6 +33,7 @@
 (deftask development []
   (task-options! cljs {:optimizations :none
                        :unified-mode true
+                       :compiler-options {:asset-path "js/app.out"}
                        :source-map true}
                  reload {:on-jsload '{{name}}.app/init}{{{development-task-opts}}})
   identity)

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -1,9 +1,9 @@
 (set-env!
  :source-paths    {{{source-paths}}}
  :resource-paths  #{"resources"}
-                 [adzerk/boot-cljs-repl     "0.1.9"      :scope "test"]
-                 [adzerk/boot-reload        "0.3.1"      :scope "test"]
  :dependencies '[[adzerk/boot-cljs          "1.7.48-6"   :scope "test"]
+                 [adzerk/boot-cljs-repl     "0.2.0"      :scope "test"]
+                 [adzerk/boot-reload        "0.4.1"      :scope "test"]
                  [pandeiro/boot-http        "0.6.3"      :scope "test"]
                  [org.clojure/clojurescript "1.7.122"]{{{deps}}}])
 

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -32,7 +32,6 @@
 
 (deftask development []
   (task-options! cljs {:optimizations :none
-                       :unified-mode true
                        :compiler-options {:asset-path "js/app.out"}
                        :source-map true}
                  reload {:on-jsload '{{name}}.app/init}{{{development-task-opts}}})


### PR DESCRIPTION
In case you're interested @martinklepsch -- I've bumped the deps.

Good news is that reload and cljs-repl are working. One less good bit was that I had to specify `:compiler-options {:asset-path "js/app.out"}`, which would obviously not work if multiple builds were involved (they'd have different paths).
