### PR TITLE
Add /out to gitignore

### DIFF
--- a/resources/leiningen/new/tenzing/gitignore
+++ b/resources/leiningen/new/tenzing/gitignore
@@ -1,2 +1,3 @@
 /target
 /.nrepl-port
+/out


### PR DESCRIPTION
When using `boot dev` cljs and js files are dumped by the compiler into `out` which makes it a good candidate for `.gitignore`.