### PR TITLE
Silence boot warning about implicit target deprecation in generated projects

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tenzing/lein-template "0.3.6"
+(defproject tenzing/lein-template "0.3.7-SNAPSHOT"
   :description "Clojurescript application template built on Boot"
   :url "http://github.com/martinklepsch/tenzing"
   :license {:name "Eclipse Public License"

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -20,7 +20,8 @@
   (comp (speak)
         {{{pre-build-steps}}}
         (cljs)
-        {{{build-steps}}}))
+        {{{build-steps}}}
+        (target :dir #{"target"})))
 
 (deftask run []
   (comp (serve)

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -10,6 +10,8 @@
                  [weasel                    "0.7.0"      :scope "test"]
                  [org.clojure/clojurescript "1.7.228"]{{{deps}}}])
 
+(def write-to-target (atom false))
+
 (require
  '[adzerk.boot-cljs      :refer [cljs]]
  '[adzerk.boot-cljs-repl :refer [cljs-repl start-repl]]
@@ -21,7 +23,9 @@
         {{{pre-build-steps}}}
         (cljs)
         {{{build-steps}}}
-        (target :dir #{"target"})))
+        (if @write-to-target
+          (target :dir #{"target"})
+          identity)))
 
 (deftask run []
   (comp (serve)
@@ -32,6 +36,7 @@
 
 (deftask production []
   (task-options! cljs {:optimizations :advanced}{{{production-task-opts}}})
+  (reset! write-to-target true)
   identity)
 
 (deftask development []

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -125,8 +125,7 @@
           (garden? opts) (conj (str "(garden :styles-var '" name ".styles/screen\n:output-to \"css/garden.css\")"))
           (sass?   opts) (conj (str "(sass :output-dir \"css\")"))
           (less?   opts) (conj (str "(less)"))
-          (less?   opts) (conj (str "(sift   :move {#\"less.css\" \"css/less.css\" #\"less.main.css.map\" \"css/less.main.css.map\"})"))
-          true           (conj (str "(target :dir #{\"target\"})"))))
+          (less?   opts) (conj (str "(sift   :move {#\"less.css\" \"css/less.css\" #\"less.main.css.map\" \"css/less.main.css.map\"})"))))
 
 (defn production-task-opts [opts]
   (cond-> []

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -125,7 +125,8 @@
           (garden? opts) (conj (str "(garden :styles-var '" name ".styles/screen\n:output-to \"css/garden.css\")"))
           (sass?   opts) (conj (str "(sass :output-dir \"css\")"))
           (less?   opts) (conj (str "(less)"))
-          (less?   opts) (conj (str "(sift   :move {#\"less.css\" \"css/less.css\" #\"less.main.css.map\" \"css/less.main.css.map\"})"))))
+          (less?   opts) (conj (str "(sift   :move {#\"less.css\" \"css/less.css\" #\"less.main.css.map\" \"css/less.main.css.map\"})"))
+          true           (conj (str "(target :dir #{\"target\"})"))))
 
 (defn production-task-opts [opts]
   (cond-> []
@@ -179,6 +180,13 @@
       (println "WARNING: unable to produce boot.properties file.")
       out)))
 
+(defn silence-implicit-target-warning [boot-props]
+  (let [line-sep (System/getProperty "line.separator")]
+    (string/join line-sep 
+                 (conj (string/split (render-boot-properties) 
+                                     (re-pattern line-sep)) 
+                       (str "BOOT_EMIT_TARGET=no" line-sep)))))
+
 (defn tenzing
   "Main function to generate new tenzing project."
   [name & opts]
@@ -203,7 +211,7 @@
                            ["resources/index.html" (render "index.html" data)]
 
                            (when-let [boot-props (render-boot-properties)]
-                             ["boot.properties" boot-props])
+                             ["boot.properties" (silence-implicit-target-warning boot-props)])
 
                            ["build.boot" (render "build.boot" data)]
                            [".gitignore" (render "gitignore" data)])))))


### PR DESCRIPTION
This PR follows the recommendations in the [boot FAQ](https://github.com/boot-clj/boot/wiki/FAQ).

The implicit `target` task is deprecated. In order to silence the warning about this, an explicit `target` task is added and the deprecated behaviour is switched off by putting `BOOT_EMIT_TARGET=no` in `boot.properties`.

This should also take care of issue #60.