### PR TITLE
Update README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,9 @@ You can learn more about Boot in
 [a blog post by one of the authors](http://adzerk.com/blog/2014/11/clojurescript-builds-rebooted/),
 its [github project](https://github.com/boot-clj/boot) or
 [a blog post I wrote about it](http://www.martinklepsch.org/posts/why-boot-is-relevant-for-the-clojure-ecosystem.html).
+[Mimmo Costanza's modern-cljs tutorial](https://github.com/magomimmo/modern-cljs) also uses Boot throughout - 
+[Tutorial 2](https://github.com/magomimmo/modern-cljs/blob/master/doc/second-edition/tutorial-02.md)
+walks through the setup of a typical Boot-based development environment.
 
 ## Why #noBackend?
 

--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ walks through the setup of a typical Boot-based development environment.
 
 Tenzing is designed with prototyping in mind. Instead of writing your
 own backend you're encouraged to use services like
-[Parse](https://parse.com), [Firebase](https://www.firebase.com),
+[Firebase](https://www.firebase.com),
 [Usergrid](http://usergrid.incubator.apache.org) and others.
 
 If you figure out that you need a Clojure based backend down the road

--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ making sure that build steps don't interfere with each other.
 
 You can learn more about Boot in
 [a blog post by one of the authors](http://adzerk.com/blog/2014/11/clojurescript-builds-rebooted/),
-it's [github project](https://github.com/boot-clj/boot) or
+its [github project](https://github.com/boot-clj/boot) or
 [a blog post I wrote about it](http://www.martinklepsch.org/posts/why-boot-is-relevant-for-the-clojure-ecosystem.html).
 
 ## Why #noBackend?


### PR DESCRIPTION
Minor changes to README:

Add link to modern-cljs tutorial (see comments in #60)
Remove to link to Parse service - it's shutting down
Fix apostrophe :)