### PR TITLE
Upgrade boot-reload, to support boot ^2.6.x

### DIFF
--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -3,7 +3,7 @@
  :resource-paths  #{"resources"}
  :dependencies '[[adzerk/boot-cljs          "1.7.228-1"  :scope "test"]
                  [adzerk/boot-cljs-repl     "0.3.0"      :scope "test"]
-                 [adzerk/boot-reload        "0.4.5"      :scope "test"]
+                 [adzerk/boot-reload        "0.4.8"      :scope "test"]
                  [pandeiro/boot-http        "0.7.2"      :scope "test"]
                  [com.cemerick/piggieback   "0.2.1"      :scope "test"]
                  [org.clojure/tools.nrepl   "0.2.12"     :scope "test"]


### PR DESCRIPTION
Closes #69.

Can't spot anything backwards-breaking in [their changelog](https://github.com/adzerk-oss/boot-reload/blob/master/CHANGELOG.md)