### PR TITLE
Remove source map option from cljs build

### DIFF
--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -34,7 +34,7 @@
   identity)
 
 (deftask development []
-  (task-options! cljs {:optimizations :none :source-map true}
+  (task-options! cljs {:optimizations :none}
                  reload {:on-jsload '{{name}}.app/init}{{{development-task-opts}}})
   identity)
 


### PR DESCRIPTION
As advised in https://github.com/adzerk-oss/boot-cljs/issues/136