### PR TITLE
Use boot-cljs-2.0.0

### DIFF
--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -4,7 +4,7 @@
  :dependencies '[[adzerk/boot-cljs          "2.0.0"      :scope "test"]
                  [adzerk/boot-cljs-repl     "0.3.3"      :scope "test"]
                  [adzerk/boot-reload        "0.5.1"      :scope "test"]
-                 [pandeiro/boot-http        "0.7.6"      :scope "test"]
+                 [pandeiro/boot-http        "0.8.3"      :scope "test"]
                  [com.cemerick/piggieback   "0.2.1"      :scope "test"]
                  [org.clojure/tools.nrepl   "0.2.12"     :scope "test"]
                  [weasel                    "0.7.0"      :scope "test"]

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -8,7 +8,7 @@
                  [com.cemerick/piggieback   "0.2.1"      :scope "test"]
                  [org.clojure/tools.nrepl   "0.2.12"     :scope "test"]
                  [weasel                    "0.7.0"      :scope "test"]
-                 [org.clojure/clojurescript "1.9.293"]{{{deps}}}])
+                 [org.clojure/clojurescript "1.9.562"]{{{deps}}}])
 
 (require
  '[adzerk.boot-cljs      :refer [cljs]]

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :source-paths    {{{source-paths}}}
  :resource-paths  #{"resources"}
- :dependencies '[[adzerk/boot-cljs          "1.7.228-2"  :scope "test"]
+ :dependencies '[[adzerk/boot-cljs          "2.0.0"      :scope "test"]
                  [adzerk/boot-cljs-repl     "0.3.3"      :scope "test"]
                  [adzerk/boot-reload        "0.4.13"      :scope "test"]
                  [pandeiro/boot-http        "0.7.6"      :scope "test"]

--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -3,7 +3,7 @@
  :resource-paths  #{"resources"}
  :dependencies '[[adzerk/boot-cljs          "2.0.0"      :scope "test"]
                  [adzerk/boot-cljs-repl     "0.3.3"      :scope "test"]
-                 [adzerk/boot-reload        "0.4.13"      :scope "test"]
+                 [adzerk/boot-reload        "0.5.1"      :scope "test"]
                  [pandeiro/boot-http        "0.7.6"      :scope "test"]
                  [com.cemerick/piggieback   "0.2.1"      :scope "test"]
                  [org.clojure/tools.nrepl   "0.2.12"     :scope "test"]


### PR DESCRIPTION
Addresses #81 

Also updates the following dependencies in generated projects:

- [clojurescipt](https://github.com/clojure/clojurescript) -> 1.9.562
- [boot-reload](https://github.com/adzerk-oss/boot-reload) -> 0.5.1
- [boot-http](https://github.com/pandeiro/boot-http) -> 0.8.3

I've manually tested projects generated with the various +options and haven't seen any breakages so far.