### PR TITLE
Update dirac, devtools

### DIFF
--- a/resources/leiningen/new/tenzing/build.boot
+++ b/resources/leiningen/new/tenzing/build.boot
@@ -6,7 +6,7 @@
                  [adzerk/boot-reload        "0.4.13"      :scope "test"]
                  [pandeiro/boot-http        "0.7.6"      :scope "test"]
                  [com.cemerick/piggieback   "0.2.1"      :scope "test"]
-                 [org.clojure/tools.nrepl   "0.2.12"     :scope "test"]
+                 [org.clojure/tools.nrepl   "0.2.13"     :scope "test"]
                  [weasel                    "0.7.0"      :scope "test"]
                  [org.clojure/clojurescript "1.9.293"]{{{deps}}}])
 

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -105,7 +105,7 @@
           (sass?     opts)           (conj "org.slf4j/slf4j-nop  \"1.7.21\" :scope \"test\"")
           (less?     opts)           (conj "deraen/boot-less \"0.6.0\" :scope \"test\"")
           (devtools? opts)           (conj "binaryage/devtools \"0.9.0\" :scope \"test\"")
-          (dirac?    opts)           (conj "binaryage/dirac \"1.1.3\" :scope \"test\"")
+          (dirac?    opts)           (conj "binaryage/dirac \"1.2.9\" :scope \"test\"")
           (boot-cljs-devtools? opts) (conj "powerlaces/boot-cljs-devtools \"0.2.0\" :scope \"test\"")))
 
 (defn build-requires [opts]

--- a/src/leiningen/new/tenzing.clj
+++ b/src/leiningen/new/tenzing.clj
@@ -104,7 +104,7 @@
           (sass?     opts)           (conj "deraen/boot-sass  \"0.3.0\" :scope \"test\"")
           (sass?     opts)           (conj "org.slf4j/slf4j-nop  \"1.7.21\" :scope \"test\"")
           (less?     opts)           (conj "deraen/boot-less \"0.6.0\" :scope \"test\"")
-          (devtools? opts)           (conj "binaryage/devtools \"0.9.0\" :scope \"test\"")
+          (devtools? opts)           (conj "binaryage/devtools \"0.9.4\" :scope \"test\"")
           (dirac?    opts)           (conj "binaryage/dirac \"1.2.9\" :scope \"test\"")
           (boot-cljs-devtools? opts) (conj "powerlaces/boot-cljs-devtools \"0.2.0\" :scope \"test\"")))
 


### PR DESCRIPTION
This PR updates [dirac](https://github.com/binaryage/dirac) and [cljs-devtools](https://github.com/binaryage/cljs-devtools) to the most recent versions so that generated projects work out-of-the-box with the current [diract devtools plugin](https://chrome.google.com/webstore/detail/dirac-devtools/kbkdngfljkchidcjpnfcgcokkbhlkogi?hl=en).

[tools-nrepl](https://github.com/clojure/tools.nrepl) is also updated to 0.2.13.

- supercedes #80 
- plays nicely with #82 