### PR TITLE
Actualize README boot new example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,13 +63,13 @@ approach for building early iterations of your application.
 To create a new project, [install boot](https://github.com/boot-clj/boot#install) and run:
 
 ```shell
-$ boot -d seancorfield/boot-new new -t tenzing -n your-app
+$ boot -d boot/new new -t tenzing -n your-app
 ```
 
 Template options are specified using the `-a` switch. For example:
 
 ```shell
-$ boot -d seancorfield/boot-new new -t tenzing -n your-app -a +reagent -a +test
+$ boot -d boot/new new -t tenzing -n your-app -a +reagent -a +test
 ```
 
 Alternatively, if you have leiningen installed, you can run


### PR DESCRIPTION
Use boot/new instead of seancorfield/boot-new in README example
because of seancorfield/boot-new has moved to
the Boot organization, as boot-clj/boot-new
and that the group/artifact ID is now boot/new